### PR TITLE
Add Enum for Schema Field Value Constraints

### DIFF
--- a/src/models/onboarding.ts
+++ b/src/models/onboarding.ts
@@ -1,6 +1,6 @@
 import { Model, Schema, model, models } from 'mongoose'
 
-import { PlatformType } from '@diia-inhouse/types'
+import { PlatformType, SessionType } from '@diia-inhouse/types'
 
 import { boardSchema } from './schemas/board'
 
@@ -31,7 +31,7 @@ const onboardingSchema = new Schema<Onboarding>(
         platformType: { type: String, enum: Object.values(PlatformType), required: true },
         isVisible: { type: Boolean, required: true },
         data: { type: onboardingDataSchema, required: true },
-        sessionType: { type: String, required: true },
+        sessionType: { type: String, enum: Object.values(SessionType), required: true },
     },
     {
         timestamps: true,

--- a/src/models/userDocument.ts
+++ b/src/models/userDocument.ts
@@ -1,6 +1,6 @@
 import { Model, Schema, SchemaDefinition, model, models } from 'mongoose'
 
-import { DocumentType, OwnerType } from '@diia-inhouse/types'
+import { DocStatus, DocumentType, OwnerType, UserDocumentSubtype } from '@diia-inhouse/types'
 
 import { UserDocument, UserDocumentsNotifications } from '@interfaces/models/userDocument'
 import { ComparedTo, UserCompoundDocument } from '@interfaces/services/documents'
@@ -39,12 +39,12 @@ const userDocumentSchema = new Schema<UserDocument>(
         userIdentifier: { type: String, required: true },
         mobileUid: { type: String, index: true },
         documentType: { type: String, enum: Object.values(DocumentType), required: true },
-        documentSubType: { type: String },
+        documentSubType: { type: String, enum: Object.values(UserDocumentSubtype) },
         documentIdentifier: { type: String, required: true, index: true },
         normalizedDocumentIdentifier: { type: String, index: true },
         ownerType: { type: String, enum: Object.values(OwnerType), required: true },
         docId: { type: String },
-        docStatus: { type: Number },
+        docStatus: { type: Number, enum: Object.values(DocStatus) },
         documentData: { type: Object },
         compoundDocument: { type: userCompoundDocumentSchema },
         registrationDate: { type: Date },

--- a/src/models/userSigningHistoryItem.ts
+++ b/src/models/userSigningHistoryItem.ts
@@ -1,5 +1,7 @@
 import { Model, Schema, model, models } from 'mongoose'
 
+import { DocumentType, PlatformType } from '@diia-inhouse/types'
+
 import { SignAlgo } from '@interfaces/models/diiaId'
 import {
     SigningHistoryAcquirer,
@@ -56,12 +58,12 @@ const userSigningHistoryItemSchema = new Schema<UserSigningHistoryItem>(
         userIdentifier: { type: String, index: true, required: true },
         sessionId: { type: String, index: true, required: true },
         resourceId: { type: String, required: true },
-        platformType: { type: String },
+        platformType: { type: String, enum: Object.values(PlatformType) },
         platformVersion: { type: String },
         action: { type: String },
         status: { type: String, enum: Object.values(UserHistoryItemStatus), index: true, required: true },
         statusHistory: { type: [statusHistoryItemSchema], required: true },
-        documents: { type: [String], required: true },
+        documents: { type: [String], enum: Object.values(DocumentType), required: true },
         date: { type: Date, required: true },
         acquirer: { type: acquirerSchema },
         offer: { type: offerSchema },


### PR DESCRIPTION
This pull request adds missed enum to enforce strict constraints on the possible values of Schema fields.
It ensures that only valid values are accepted, reducing the potential for errors.





