### PR TITLE
Improving OTP generation

### DIFF
--- a/src/services/otp.ts
+++ b/src/services/otp.ts
@@ -1,3 +1,4 @@
+import { randomInt } from 'crypto'
 import { ObjectId } from 'bson'
 import moment from 'moment'
 import { FilterQuery, UpdateQuery } from 'mongoose'
@@ -28,7 +29,7 @@ export default class OtpService {
             throw new AccessDeniedError('Exceeded otps limits per day', undefined, ProcessCode.OtpSendAttemptsExceeded)
         }
 
-        const value: number = Math.floor(1000 + Math.random() * 9000)
+        const value: string = this.generateOtp(4)
 
         await this.notificationService.sendSms(phoneNumber, SmsTemplateCode.Otp, user, headers, value.toString())
 
@@ -105,5 +106,9 @@ export default class OtpService {
                 $lt: new Date(moment.utc().endOf('day').valueOf()),
             },
         })
+    }
+
+    private generateOtp(length: number): string {
+        return Array.from({ length }, () => randomInt(0, 10)).join('')
     }
 }


### PR DESCRIPTION
I'd like to propose a minor improvement aimed at enhancing the cryptographic strength and expanding the capabilities of OTP generation. Specifically, this would enable the creation of OTPs that can start with zero and allow for dynamically defining the length of the OTP.

Additionally, if the functionality is sufficiently generic and does not include business logic specific to a single service, consider the possibility of extracting such code into a common library that can be utilized by both services. This will ensure code reusability and prevent duplication. For microservices, this often pertains to utility functions, such as OTP generation.

I also recommend increasing the minimum length of the length parameter for OTPs from 4 to 6-8 characters. You might also consider storing the value of the length parameter in the configuration.